### PR TITLE
Implements ARM64 filter described in xz spec version 1.1.0.

### DIFF
--- a/src/org/tukaani/xz/ARM64Options.java
+++ b/src/org/tukaani/xz/ARM64Options.java
@@ -1,0 +1,37 @@
+/*
+ * ARM64Options
+ *
+ * Author: Jia Tan <jiat0218@gmail.com>
+ *
+ * This file has been put into the public domain.
+ * You can do whatever you want with this file.
+ */
+
+package org.tukaani.xz;
+
+import java.io.InputStream;
+import org.tukaani.xz.simple.ARM64;
+
+/**
+ * BCJ filter for little endian ARM64 instructions.
+ */
+public class ARM64Options extends BCJOptions {
+    private static final int ALIGNMENT = 4;
+
+    public ARM64Options() {
+        super(ALIGNMENT);
+    }
+
+    public FinishableOutputStream getOutputStream(FinishableOutputStream out,
+                                                  ArrayCache arrayCache) {
+        return new SimpleOutputStream(out, new ARM64(true, startOffset));
+    }
+
+    public InputStream getInputStream(InputStream in, ArrayCache arrayCache) {
+        return new SimpleInputStream(in, new ARM64(false, startOffset));
+    }
+
+    FilterEncoder getFilterEncoder() {
+        return new BCJEncoder(this, BCJCoder.ARM64_FILTER_ID);
+    }
+}

--- a/src/org/tukaani/xz/BCJCoder.java
+++ b/src/org/tukaani/xz/BCJCoder.java
@@ -16,9 +16,10 @@ abstract class BCJCoder implements FilterCoder {
     public static final long ARM_FILTER_ID = 0x07;
     public static final long ARMTHUMB_FILTER_ID = 0x08;
     public static final long SPARC_FILTER_ID = 0x09;
+    public static final long ARM64_FILTER_ID = 0X0A;
 
     public static boolean isBCJFilterID(long filterID) {
-        return filterID >= 0x04 && filterID <= 0x09;
+        return filterID >= X86_FILTER_ID && filterID <= ARM64_FILTER_ID;
     }
 
     public boolean changesSize() {

--- a/src/org/tukaani/xz/BCJDecoder.java
+++ b/src/org/tukaani/xz/BCJDecoder.java
@@ -54,6 +54,8 @@ class BCJDecoder extends BCJCoder implements FilterDecoder {
             simpleFilter = new ARMThumb(false, startOffset);
         else if (filterID == SPARC_FILTER_ID)
             simpleFilter = new SPARC(false, startOffset);
+        else if (filterID == ARM64_FILTER_ID)
+            simpleFilter = new ARM64(false, startOffset);
         else
             assert false;
 

--- a/src/org/tukaani/xz/simple/ARM64.java
+++ b/src/org/tukaani/xz/simple/ARM64.java
@@ -1,0 +1,136 @@
+/*
+ * BCJ filter for little endian ARM64 instructions
+ *
+ * Authors: Jia Tan <jiat0218@gmail.com>
+ *          Lasse Collin <lasse.collin@tukaani.org>
+ *          Igor Pavlov <http://7-zip.org/>
+ *
+ * This file has been put into the public domain.
+ * You can do whatever you want with this file.
+ */
+
+package org.tukaani.xz.simple;
+
+public final class ARM64 implements SimpleFilter {
+    private final boolean isEncoder;
+    private int pos;
+
+    public ARM64(boolean isEncoder, int startPos) {
+        this.isEncoder = isEncoder;
+        pos = startPos;
+    }
+
+    public int code(byte[] buf, int off, int len) {
+        int end = off + len - 4;
+        int i;
+
+        for (i = off; i <= end; i += 4) {
+            // Handle BL instruction:
+            // Convert the full 26 bit immediate, do not ignore any bits
+            // for possible false positives. The full range gives important
+            // compression ratio improvements for large files, but suffers
+            // slightly on small files.
+            if ((buf[i + 3] & 0xFC) == 0x94) {
+                int src = ((buf[i + 3] & 0x03) << 24)
+                          | ((buf[i + 2] & 0xFF) << 16)
+                          | ((buf[i + 1] & 0xFF) << 8)
+                          | (buf[i] & 0xFF);
+
+                // Instead of shifting the immediate, we shift the program
+                // counter so we do not have to shift the destination value
+                // back by 2.
+                final int pc = (pos + i - off) >>> 2;
+
+                int dest;
+                if (isEncoder)
+                    dest = src + pc;
+                else
+                    dest = src - pc;
+
+                buf[i + 3] = (byte)(0x94 | ((dest >>> 24) & 0x3));
+                buf[i + 2] = (byte)(dest >>> 16);
+                buf[i + 1] = (byte)(dest >>> 8);
+                buf[i] = (byte)dest;
+
+            } else if ((buf[i + 3] & 0x9F) == 0x90) {
+                // Handle ADRP instruction:
+                // Ignore data that appears to be a ADRP instruction if
+                // the highest 3 bits in the immediate are not all the same.
+                // In practice, this limits the immediate range to +/- 512 MiB,
+                // which is large enough for a majority of actual ARM64
+                // binary data. This reduces false positives of data that
+                // is not ADRP instructions.
+                int instruction = ((buf[i + 3] & 0xFF) << 24)
+                                  | ((buf[i + 2] & 0xFF) << 16)
+                                  | ((buf[i + 1] & 0xFF) << 8)
+                                  | (buf[i] & 0xFF);
+
+                // The ADRP instruction in AArch64:
+                // Bits 0 - 4: Destination register.
+                // Bits 5 - 23: High bits of immediate.
+                // Bits 24 - 28: Op code.
+                // Bits 29 - 30: Low bits of immediate.
+                // Bit 31: Op code.
+                //
+                // When an ADRP instruction is executed, the immediate is
+                // shifted left by 12 and the bottom 12 bits are then masked
+                // out. The immediate is added to the program counter, then
+                // stored in the destination register.
+                final int src = ((instruction >>> 29) & 3)
+                                | ((instruction >>> 3) & 0x001FFFFC);
+
+                // This addition is an optimization to avoid the need for two
+                // checks for accepted +/- range. The more readable code
+                // would check if any of the four highest bits (3 ignored and
+                // 1 sign bit) are set and if so, they all must be set which
+                // would indicate a negative immediate. The readable version:
+                // if ((src & 0x001E0000) != 0
+                //     && (src & 0x001E0000 != 0x001E0000))
+                //     continue;
+                //
+                // 0x001C0000 has the highest 3 bits set in the immediate.
+                // 0x00020000 has the 17th bit set
+                // If this addition results in any of the 3 highest bits set:
+                // - The src already had one or more of the 4 highest bits
+                //   set, but not all of them set (too large positive).
+                // - The src was a very large negative so the addition did
+                //   not flip the 3 highest bits in the immediate.
+                if (((src + 0x00020000) & 0x001C0000) != 0)
+                    continue;
+
+                final int pc = (pos + i - off) >>> 12;
+
+                int dest;
+                if (isEncoder)
+                    dest = src + pc;
+                else
+                    dest = src - pc;
+
+                // Clear out all bits except for the opcode and original
+                // destination register.
+                instruction &= 0x9000001F;
+
+                // Shift the new low bits back to bits 29 - 30.
+                instruction |= (dest & 3) << 29;
+
+                // Shift the new high bits back to bits 5 - 20.
+                // AND out bits 21-23.
+                instruction |= (dest & 0x0003FFFC) << 3;
+
+                // If the immediate is negative (17th bit set before shifting)
+                // ensure bits 21-23 (after shifting) are set. This ensures
+                // proper sign extension.
+                instruction |= (0 - (dest & 0x00020000)) & 0x00E00000;
+
+                buf[i + 3] = (byte)(instruction >>> 24);
+                buf[i + 2] = (byte)(instruction >>> 16);
+                buf[i + 1] = (byte)(instruction >>> 8);
+                buf[i] = (byte)(instruction);
+            }
+        }
+
+        i -= off;
+        pos += i;
+        return i;
+    }
+}


### PR DESCRIPTION
The ARM64 filter (ID 0x0A) is compatible with the XZ Utils version for compression and decompression. It converts BL and ADRP instructions from relative to absolute addresses. Implementation was largely inspired by the C version in XZ Utils, especially the optimization for checking ADRP false positive range limitations.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, XZ Java does not have support for the brand new ARM64 filter.

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->

- Adds compatible support with XZ Utils for the new ARM64 filter (ID 0xA)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->