### PR TITLE
fix sign extension when decoding Backward Size

### DIFF
--- a/src/org/tukaani/xz/common/DecoderUtil.java
+++ b/src/org/tukaani/xz/common/DecoderUtil.java
@@ -66,7 +66,7 @@ public class DecoderUtil extends Util {
 
         streamFlags.backwardSize = 0;
         for (int i = 0; i < 4; ++i)
-            streamFlags.backwardSize |= (buf[i + 4] & 0xFF) << (i * 8);
+            streamFlags.backwardSize |= (long)(buf[i + 4] & 0xFF) << (i * 8);
 
         streamFlags.backwardSize = (streamFlags.backwardSize + 1) * 4;
 


### PR DESCRIPTION
Backward Size is an unsigned 32-bit field, but decodeStreamFooter ORs each byte into a long without widening, so a most-significant byte >= 0x80 makes the int shift sign-extend and yields a negative backwardSize. That value slips past the `backwardSize >= pos` check in SeekableXZInputStream and leads to an out-of-range seek. Widen the byte to long before shifting, like uncompSize in LZMAInputStream.